### PR TITLE
OS X Support and some Linux fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # enpass-cli
 Linux and Mac OS X Enpass commandline client
 
-Based on [encpass-decryptor by steffen9000](https://github.com/steffen9000/enpass-decryptor), this repository forked from [enpass-cli](https://github.com/HazCod/enpass-cli)
+Based on [encpass-decryptor by steffen9000](https://github.com/steffen9000/enpass-decryptor)
 
 -- Installation
 
 Required system packages: `sqlcipher-dev` `python3`  `git`
 
-Get the code:             `git clone https://github.com/heywoodlh/enpass-cli pass && cd pass/`
+Get the code:             `git clone https://github.com/HazCod/enpass-cli pass && cd pass/`
 
 Required python packages: `python -m pip install -r requirements.txt`
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Based on [encpass-decryptor by steffen9000](https://github.com/steffen9000/enpas
 
 Required system packages: `sqlcipher-dev` `python3`  `git`
 
-Get the code:             `git clone https://github.com/HazCod/enpass-cli pass && cd pass/`
+Get the code:             `git clone https://github.com/heywoodlh/enpass-cli pass && cd pass/`
 
 Required python packages: `python -m pip install -r requirements.txt`
 

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ Specify another walletx file using the -w argument:
 `pass -w=/Users/user/alternate-dir/walletx.db copy github`
 
 
- Delete password stored in keyring:
- python3
+ Delete password stored in keyring for OS X users:
+ python3 -c "import keyring; keyring.delete_password('enpass', 'enpass')"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Required python packages: `python -m pip install -r requirements.txt`
 
 Add this to your .bashrc: `eval "$(register-python-argcomplete pass)"`
 
-Symlink to 'pass':	  `sudo ln -s /usr/bin/pass pass/pass.py && sudo chown $USER /usr/bin/pass && chown 555 /usr/bin/pass`
+Symlink to 'pass':	  `sudo cp pass.py /usr/local/bin/pass && sudo chown $USER /usr/local/bin/pass`
 
 
 -- Usage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # enpass-cli
-Mac OS X Enpass commandline client
+Linux and Mac OS X Enpass commandline client
 
 Based on [encpass-decryptor by steffen9000](https://github.com/steffen9000/enpass-decryptor), this repository forked from [enpass-cli](https://github.com/HazCod/enpass-cli)
 
@@ -31,3 +31,7 @@ Specify another walletx file using the -w argument:
 `pass -w=/Users/user/alternate-dir/walletx.db get github`
 
 `pass -w=/Users/user/alternate-dir/walletx.db copy github`
+
+
+ Delete password stored in keyring:
+ python3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Required system packages: `sqlcipher-dev` `python3`  `git`
 
 Get the code:             `git clone https://github.com/heywoodlh/enpass-cli pass && cd pass/`
 
-Required python packages: `python -m pip install -r requirements.txt`
+Required python packages: `pip3 install -r requirements.txt`
 
 Add this to your .bashrc: `eval "$(register-python-argcomplete pass)"`
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # enpass-cli
-Enpass commandline client
+Mac OS X Enpass commandline client
 
-Based on [encpass-decryptor by steffen9000](https://github.com/steffen9000/enpass-decryptor)
+Based on [encpass-decryptor by steffen9000](https://github.com/steffen9000/enpass-decryptor), this repository forked from [enpass-cli](https://github.com/HazCod/enpass-cli)
 
 -- Installation
 
-Required system packages: `sqlcipher-dev` `python3` `xclip` `git`
+Required system packages: `sqlcipher-dev` `python3`  `git`
 
-Get the code:             `git clone https://github.com/HazCod/enpass-cli pass && cd pass/`
+Get the code:             `git clone https://github.com/heywoodlh/enpass-cli pass && cd pass/`
 
 Required python packages: `python -m pip install -r requirements.txt`
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Symlink to 'pass':	  `sudo ln -s /usr/bin/pass pass/pass.py && sudo chown $USER 
 
 `pass --help`
 
-`pass -w=/home/user/Enpass/walletx.db get github`
+If enpass has already been initialized and using the default ~/Documents/Enpass/walletx.db use this syntax:
 
-`pass -w=/home/user/Enpass/walletx.db copy github`
+`pass get github`
+
+`pass copy github`
+
+Specify another walletx file using the -w argument:
+
+`pass -w=/Users/user/alternate-dir/walletx.db get github`
+
+`pass -w=/Users/user/alternate-dir/walletx.db copy github`

--- a/pass.py
+++ b/pass.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
-
-from pysqlcipher3 import dbapi2 as sqlite
 from Crypto.Cipher import AES
 import hashlib, binascii
 
@@ -18,12 +16,14 @@ import keyring
 wallet = os.getenv('HOME') + '/Documents/Enpass/walletx.db'
 
 if sys.platform == 'darwin':
+    from pysqlcipher3 import dbapi2 as sqlite
     def copyToClip(message):
         p = subprocess.Popen(['pbcopy'],
                             stdin=subprocess.PIPE, close_fds=True)
         p.communicate(input=message.encode('utf-8'))
 
 if sys.platform == 'linux':
+    from sqlite3 import dbapi2
     def copyToClip(message):
         p = subprocess.Popen(['xclip', '-in', '-selection', 'clipboard'],
                             stdin=subprocess.PIPE, close_fds=True)

--- a/pass.py
+++ b/pass.py
@@ -160,7 +160,7 @@ def main(argv=None):
     if password_saved is None:
         response = input('Would you like to save your master password in the keyring? (Y/n)')
         if response == 'Y':
-            keyring.set_password('enpass', 'enpass', password)
+            keyring.set_password('enpass', 'enpass', str(password))
     else:
         password = keyring.get_password('enpass', 'enpass')
 

--- a/pass.py
+++ b/pass.py
@@ -18,8 +18,15 @@ import sys
 global wallet
 wallet = os.getenv('HOME') + '/Documents/Enpass/walletx.db'
 
-def copyToClip(message):
-    p = subprocess.Popen(['pbcopy'],
+if sys.platform == 'darwin':
+    def copyToClip(message):
+        p = subprocess.Popen(['pbcopy'],
+                            stdin=subprocess.PIPE, close_fds=True)
+        p.communicate(input=message.encode('utf-8'))
+
+if sys.platform == 'linux':
+    def copyToClip(message):
+    p = subprocess.Popen(['xclip', '-in', '-selection', 'clipboard'],
                          stdin=subprocess.PIPE, close_fds=True)
     p.communicate(input=message.encode('utf-8'))
 

--- a/pass.py
+++ b/pass.py
@@ -23,7 +23,7 @@ if sys.platform == 'darwin':
         p.communicate(input=message.encode('utf-8'))
 
 if sys.platform == 'linux':
-    from sqlite3 import dbapi2
+    from sqlite3 import dbapi2 as sqlite
     def copyToClip(message):
         p = subprocess.Popen(['xclip', '-in', '-selection', 'clipboard'],
                             stdin=subprocess.PIPE, close_fds=True)

--- a/pass.py
+++ b/pass.py
@@ -164,7 +164,7 @@ def main(argv=None):
     else:
         password = keyring.get_password('enpass', 'enpass')
 
-    en = Enpassant(wallet, password)
+    en = Enpassant(wallet, str(password))
     cards = en.getCards( name )
 
     if command == "copy":

--- a/pass.py
+++ b/pass.py
@@ -123,7 +123,7 @@ def main(argv=None):
         parser = argparse.ArgumentParser ()
 
         parser.add_argument('-w', '--wallet', help='The Enpass wallet file')
-        parser.add_argument("command", choices=('get', 'copy', 'list'), help="Show entry, list all entries, copy password")
+        parser.add_argument("command", choices=('get', 'copy'), help="Show entry, copy password")
         parser.add_argument("name", help="The entry name").completer = CardCompleter
 
         argcomplete.autocomplete( parser )
@@ -143,8 +143,8 @@ def main(argv=None):
             wallet  = argv[1]
         name    = argv[2]
 
-    if (args.command is None or args.command not in ['copy','get', 'list']):
-        print("Command: copy, get, list")
+    if (args.command is None or args.command not in ['copy','get']):
+        print("Command: copy, get")
         sys.exit(1)
 
     if not os.path.isfile( wallet ):
@@ -190,9 +190,6 @@ def main(argv=None):
 
         if (command == 'get'):
             print( pad('Note') + " :\n" + card['note'] )
-
-        if command == 'list':
-            print(cards)
 
 if __name__ == "__main__":
     exit( main() )

--- a/pass.py
+++ b/pass.py
@@ -151,18 +151,22 @@ def main(argv=None):
         print("Wallet not found: " + wallet)
         sys.exit(1)
 
-    password_saved = keyring.get_password('enpass', 'enpass')
-    if password_saved is None:
-        password = getpass.getpass( "Master Password:" )
-    else:
-        password = password_saved
+    if sys.platform == 'darwin':
+        password_saved = keyring.get_password('enpass', 'enpass')
+        if password_saved is None:
+            password = getpass.getpass( "Master Password:" )
+        else:
+            password = password_saved
 
-    if password_saved is None:
-        response = input('Would you like to save your master password in the keyring? (Y/n)')
-        if response == 'Y':
-            keyring.set_password('enpass', 'enpass', str(password))
-    else:
-        password = keyring.get_password('enpass', 'enpass')
+        if password_saved is None:
+            response = input('Would you like to save your master password in the keyring? (Y/n)')
+            if response == 'Y':
+                keyring.set_password('enpass', 'enpass', str(password))
+            else:
+                password = keyring.get_password('enpass', 'enpass')
+                
+    if sys.platform == 'linux':
+        password = getpass.getpass( "Master Password:" )
 
     en = Enpassant(wallet, str(password))
     cards = en.getCards( name )

--- a/pass.py
+++ b/pass.py
@@ -26,9 +26,9 @@ if sys.platform == 'darwin':
 
 if sys.platform == 'linux':
     def copyToClip(message):
-    p = subprocess.Popen(['xclip', '-in', '-selection', 'clipboard'],
-                         stdin=subprocess.PIPE, close_fds=True)
-    p.communicate(input=message.encode('utf-8'))
+        p = subprocess.Popen(['xclip', '-in', '-selection', 'clipboard'],
+                            stdin=subprocess.PIPE, close_fds=True)
+        p.communicate(input=message.encode('utf-8'))
 
 def pad(msg):
     return " "*2 + msg.ljust(18)

--- a/pass.py
+++ b/pass.py
@@ -13,6 +13,11 @@ import os
 import argparse, argcomplete
 import sys
 
+
+## Set up wallet variable. Change wallet variable to other location if needed
+global wallet
+wallet = os.getenv('HOME') + '/Documents/Enpass/walletx.db'
+
 def copyToClip(message):
     p = subprocess.Popen(['pbcopy'],
                          stdin=subprocess.PIPE, close_fds=True)
@@ -105,7 +110,6 @@ def CardCompleter(prefix, **kwargs):
 def main(argv=None):
     import sys
 
-    wallet  = '/home/niels/Documents/Enpass/walletx.db'
     command = ''
     name    = ''
 

--- a/pass.py
+++ b/pass.py
@@ -15,7 +15,6 @@ import sys
 
 
 ## Set up wallet variable. Change wallet variable to other location if needed
-global wallet
 wallet = os.getenv('HOME') + '/Documents/Enpass/walletx.db'
 
 if sys.platform == 'darwin':
@@ -116,6 +115,7 @@ def CardCompleter(prefix, **kwargs):
 
 def main(argv=None):
     import sys
+    global wallet
 
     command = ''
     name    = ''
@@ -140,7 +140,8 @@ def main(argv=None):
             sys.exit(1)
 
         command = argv[0]
-        wallet  = argv[1]
+        if not wallet:
+            wallet  = argv[1]
         name    = argv[2]
 
     if (args.command is None or args.command not in ['copy','get']):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pycrypto
-pysqlcipher3
-argcomplete
+argcomplete==1.9.2
+keyring==10.4.0
+pycrypto==2.6.1
+pysqlcipher3==1.0.2


### PR DESCRIPTION
General changes:
1. Changed wallet variable to point to OS agnostic "$HOME"/Documents/Enpass/walletx.db: 
`os.getenv('HOME') + '/Documents/Enpass/walletx.db'`

OS X specific changes:
1. Changed default copy utility to `pbcopy` from `xclip` if OS X is detected. If Linux is detected as OS then `xclip` is used.
2. Added keychain support if user would like to store the Master Password.

Linux specific changes:
1. Changed import statement from pysqlcipher3 to sqlite3:

from:
`from pysqlcipher3 import dbapi2 as sqlite`

to:
`from sqlite3 import dbapi2 as sqlite`
