### PR TITLE
Fixed Linux Issue and Added Keyring Prompt for Both OS X and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Based on [enpass-decryptor by steffen9000](https://github.com/steffen9000/enpass
 
 Required system packages: `sqlcipher-dev` `python3`  `git`
 
-Get the code:             `git clone https://github.com/heywoodlh/enpass-cli pass && cd pass/`
+Get the code:             `git clone https://github.com/HazCod/enpass-cli pass && cd pass/`
 
 Required python packages: `pip3 install -r requirements.txt`
 
@@ -33,5 +33,5 @@ Specify another walletx file using the -w argument:
 `pass -w=/Users/user/alternate-dir/walletx.db copy github`
 
 
- Delete password stored in keyring for OS X users:
+ Delete password stored in keyring:
  python3 -c "import keyring; keyring.delete_password('enpass', 'enpass')"

--- a/README.md
+++ b/README.md
@@ -34,4 +34,11 @@ Specify another walletx file using the -w argument:
 
 
  Delete password stored in keyring:
- python3 -c "import keyring; keyring.delete_password('enpass', 'enpass')"
+ 
+ `python3 -c "import keyring; keyring.delete_password('enpass', 'enpass')"`
+
+
+
+If you decline to store your password, an empty file is created in ~/Documents/Enpass/ called .store_decline. If you change your mind and would like to store the password, remove this file:
+
+`rm ~/Documents/Enpass/.store_decline`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # enpass-cli
 Linux and Mac OS X Enpass commandline client
 
-Based on [encpass-decryptor by steffen9000](https://github.com/steffen9000/enpass-decryptor)
+Based on [enpass-decryptor by steffen9000](https://github.com/steffen9000/enpass-decryptor)
 
 -- Installation
 

--- a/pass.py
+++ b/pass.py
@@ -19,6 +19,8 @@ from pysqlcipher3 import dbapi2 as sqlite
 ## Set up wallet variable. Change wallet variable to other location if needed
 wallet = os.getenv('HOME') + '/Documents/Enpass/walletx.db'
 
+password_store_decline = os.getenv('HOME') + '/Documents/Enpass/.store_decline'
+
 if sys.platform == 'darwin':
     def copyToClip(message):
         p = subprocess.Popen(['pbcopy'],
@@ -155,16 +157,17 @@ def main(argv=None):
         print("Wallet not found: " + wallet)
         sys.exit(1)
 
-    if sys.platform == 'darwin':
-        password = keyring.get_password('enpass', 'enpass')
-        if password is None:
-            password = getpass.getpass( "Master Password: " )
+    password = keyring.get_password('enpass', 'enpass')
+    if password is None:
+        password = getpass.getpass( "Master Password: " )
+        if os.path.isfile(password_store_decline):
+            pass
+        else:
             response = input('Would you like to save your master password in the keyring? (Y/n)').lower()
             if response == 'y' or response == '':
                 keyring.set_password('enpass', 'enpass', str(password))
-
-    if sys.platform == 'linux':
-        password = getpass.getpass( "Master Password: " )
+            else:
+                open(password_store_decline, 'w')
 
     en = Enpassant(wallet, str(password))
     cards = en.getCards( name )

--- a/pass.py
+++ b/pass.py
@@ -11,6 +11,7 @@ import os
 import argparse, argcomplete
 import sys
 import keyring
+from pysqlcipher3 import dbapi2 as sqlite
 
 ##To get all types of information decrypted run this:
 #print( pad(field['label']) +  " : " + field['type'])
@@ -19,14 +20,12 @@ import keyring
 wallet = os.getenv('HOME') + '/Documents/Enpass/walletx.db'
 
 if sys.platform == 'darwin':
-    from pysqlcipher3 import dbapi2 as sqlite
     def copyToClip(message):
         p = subprocess.Popen(['pbcopy'],
                             stdin=subprocess.PIPE, close_fds=True)
         p.communicate(input=message.encode('utf-8'))
 
 if sys.platform == 'linux':
-    from sqlite3 import dbapi2 as sqlite
     def copyToClip(message):
         p = subprocess.Popen(['xclip', '-in', '-selection', 'clipboard'],
                             stdin=subprocess.PIPE, close_fds=True)

--- a/pass.py
+++ b/pass.py
@@ -159,7 +159,7 @@ def main(argv=None):
     if sys.platform == 'darwin':
         password_saved = keyring.get_password('enpass', 'enpass')
         if password_saved is None:
-            password = getpass.getpass( "Master Password:" )
+            password = getpass.getpass( "Master Password: " )
         else:
             password = password_saved
 
@@ -171,7 +171,7 @@ def main(argv=None):
                 password = keyring.get_password('enpass', 'enpass')
 
     if sys.platform == 'linux':
-        password = getpass.getpass( "Master Password:" )
+        password = getpass.getpass( "Master Password: " )
 
     en = Enpassant(wallet, str(password))
     cards = en.getCards( name )

--- a/pass.py
+++ b/pass.py
@@ -201,6 +201,7 @@ def main(argv=None):
                 print(multi_cards)
                 print('')
                 selection = input('Select account: ')
+                selection = int(selection) - 1
                 copyToClip( pass_list[int(selection)] )
                 sys.exit(0)
             except ValueError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,12 @@
 argcomplete==1.9.2
+asn1crypto==0.23.0
+cffi==1.11.2
+cryptography==2.1.1
+idna==2.6
 keyring==10.4.0
+keyrings.alt==2.3
+pycparser==2.18
 pycrypto==2.6.1
 pysqlcipher3==1.0.2
+SecretStorage==2.3.1
+six==1.11.0


### PR DESCRIPTION
Fixed Linux issue by changing the import statement from sqlite back to pysqlcipher3 (like it originally was). 

Added prompt to store password in keyring for Linux as well.

Updated readme for ease of use.