### PR TITLE
upgrade pysqlcipher3 to 1.0.3 since 1.0.2 does not longer work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ keyring==10.4.0
 keyrings.alt==2.3
 pycparser==2.18
 pycrypto==2.6.1
-pysqlcipher3==1.0.2
+pysqlcipher3==1.0.3
 SecretStorage==2.3.1
 six==1.11.0


### PR DESCRIPTION
```
Could not find a version that satisfies the requirement pysqlcipher3==1.0.2 (from -r requirements.txt (line 10)) (from versions: 1.0.3)
No matching distribution found for pysqlcipher3==1.0.2 (from -r requirements.txt (line 10))
```

upgrading to 1.0.3 fixes that