### PR TITLE
vault.Initialize check db readability

### DIFF
--- a/pkg/enpass/vault.go
+++ b/pkg/enpass/vault.go
@@ -138,8 +138,10 @@ func (v *Vault) Initialize(databasePath string, keyfilePath string, password str
 		FROM sqlite_master
 		WHERE type='table' AND name='item'
 	`).Scan(&tableName)
-	if err != nil || tableName != "item" {
+	if err != nil {
 		return errors.Wrap(err, "could not connect to database")
+	} else if tableName != "item" {
+		return errors.New("could not connect to database")
 	}
 
 	return nil

--- a/pkg/enpass/vault.go
+++ b/pkg/enpass/vault.go
@@ -56,16 +56,6 @@ func (v *Vault) openEncryptedDatabase(path string, dbKey []byte) (err error) {
 		return errors.Wrap(err, "could not open database")
 	}
 
-	var tableName string
-	err = v.db.QueryRow(`
-		SELECT name
-		FROM sqlite_master
-		WHERE type='table' AND name='item'
-	`).Scan(&tableName)
-	if err != nil || tableName == "item" {
-		return errors.Wrap(err, "could not connect to database")
-	}
-
 	return nil
 }
 
@@ -140,6 +130,16 @@ func (v *Vault) Initialize(databasePath string, keyfilePath string, password str
 	v.Logger.Debug("opening encrypted database")
 	if err := v.openEncryptedDatabase(v.databaseFilename, fullKey); err != nil {
 		return errors.Wrap(err, "could not open encrypted database")
+	}
+
+	var tableName string
+	err = v.db.QueryRow(`
+		SELECT name
+		FROM sqlite_master
+		WHERE type='table' AND name='item'
+	`).Scan(&tableName)
+	if err != nil || tableName != "item" {
+		return errors.Wrap(err, "could not connect to database")
 	}
 
 	return nil

--- a/pkg/enpass/vault.go
+++ b/pkg/enpass/vault.go
@@ -43,6 +43,7 @@ type Vault struct {
 }
 
 func (v *Vault) openEncryptedDatabase(path string, dbKey []byte) (err error) {
+
 	// The raw key for the sqlcipher database is given
 	// by the first 64 characters of the hex-encoded key
 	dbName := fmt.Sprintf(
@@ -54,6 +55,16 @@ func (v *Vault) openEncryptedDatabase(path string, dbKey []byte) (err error) {
 	v.db, err = sql.Open("sqlite3", dbName)
 	if err != nil {
 		return errors.Wrap(err, "could not open database")
+	}
+
+	var tableName string
+	err = v.db.QueryRow(`
+		SELECT name
+		FROM sqlite_master
+		WHERE type='table' AND name='item'
+	`).Scan(&tableName)
+	if err != nil || tableName == "item" {
+		return errors.Wrap(err, "could not connect to database")
 	}
 
 	return nil

--- a/pkg/enpass/vault.go
+++ b/pkg/enpass/vault.go
@@ -43,7 +43,6 @@ type Vault struct {
 }
 
 func (v *Vault) openEncryptedDatabase(path string, dbKey []byte) (err error) {
-
 	// The raw key for the sqlcipher database is given
 	// by the first 64 characters of the hex-encoded key
 	dbName := fmt.Sprintf(


### PR DESCRIPTION
This solves #104 

[sql.Open](https://pkg.go.dev/database/sql#Open) doesn't create a connection to the database according to the documentation, thus it's not sufficient to check if the provided master password is actually correct. Additionally, we should execute a query that always runs without errors for any vault if the correct master password was provided.