### PR TITLE
add clipboardPrimary flag

### DIFF
--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -119,7 +119,8 @@ func main() {
 	logLevelStr := flag.String("log", defaultLogLevel.String(), "The log level from debug (5) to error (1).")
 	sort := flag.Bool("sort", false, "Sort the output by title and username.")
 	trashed := flag.Bool("trashed", false, "Show trashed items in output.")
-	
+	clipboardPrimary := flag.Bool("clipboardPrimary", false, "Use primary X selection instead of clipboard.")
+
 	flag.Parse()
 
 	if flag.NArg() == 0 {
@@ -179,6 +180,7 @@ func main() {
 		return
 
 	case "copy":
+		clipboard.Primary = *clipboardPrimary
 		copyEntry(logger, &vault, *cardType, filters)
 		return
 	}

--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -139,6 +139,11 @@ func main() {
 	command := strings.ToLower(flag.Arg(0))
 	filters := flag.Args()[1:]
 
+	if *clipboardPrimary {
+		clipboard.Primary = true
+		logger.Debug("primary X selection enabled")
+	}
+
 	if command == "version" {
 		logger.Printf(
 			"%s arch=%s os=%s version=%s",
@@ -180,7 +185,6 @@ func main() {
 		return
 
 	case "copy":
-		clipboard.Primary = *clipboardPrimary
 		copyEntry(logger, &vault, *cardType, filters)
 		return
 	}


### PR DESCRIPTION
Solves #106 by adding a `-clipboardPrimary` boolean flag and setting it for [clipboard](https://github.com/atotto/clipboard/blob/1438b322bde482cc6decd8bc53dbe2eece57668b/clipboard_unix.go#L27)