### PR TITLE
new command 'pass' / non-interactive mode / README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Flags
 -----
 | Name | Description |
 | :---: | --- |
-| `-vault` | Path to your Enpass vault |
-| `-keyfile` | Path to your Enpass vault keyfile |
-| `-type` | The type of your card. (password, ...) |
-| `-log` | The log level from debug (5) to error (1) |
+| `-vault=PATH` | Path to your Enpass vault |
+| `-keyfile=PATH` | Path to your Enpass vault keyfile |
+| `-type=TYPE` | The type of your card (password, ...) |
+| `-log=LEVEL` | The log level from debug (5) to error (1) |
 | `-nonInteractive` | Disable prompts and fail instead |
 | `-sort` | Sort the output by title and username of the `list` and `show` command |
 | `-trashed` | Show trashed items in the `list` and `show` command |

--- a/README.md
+++ b/README.md
@@ -13,15 +13,41 @@ CLI Usage
 $ # set an alias to easily reuse
 $ alias enp="enpasscli -vault=/my-vault-dir/ -sort"
 
+$ # list anything containing 'twitter' (without password)
+$ enp list twitter
+
 $ # show passwords of 'enpass.com'
 $ enp show enpass.com
 
 $ # copy password of 'reddit.com' entry to clipboard
 $ enp copy reddit.com
 
-$ # or list anything containing 'twitter' (without password)
-$ enp list twitter
+$ # print password of 'github.com' to stdout, useful for scripting 
+$ password=$(enp pass github.com)
 ```
+
+Commands
+-----
+| Name | Description |
+| :---: | --- |
+| `list FILTER` | List vault entries matching FILTER without password |
+| `show FILTER` | List vault entries matching FILTER with password |
+| `copy FILTER` | Copy the password of a vault entry matching FILTER to the clipboard |
+| `pass FILTER` | Print the password of a vaulty entry matching FILTER to stdout |
+| `version` | Print the version |
+
+Flags
+-----
+| Name | Description |
+| :---: | --- |
+| `-vault` | Path to your Enpass vault |
+| `-keyfile` | Path to your Enpass vault keyfile |
+| `-type` | The type of your card. (password, ...) |
+| `-log` | The log level from debug (5) to error (1) |
+| `-nonInteractive` | Disable prompts and fail instead |
+| `-sort` | Sort the output by title and username of the `list` and `show` command |
+| `-trashed` | Show trashed items in the `list` and `show` command |
+| `-clipboardPrimary` | Use primary X selection instead of clipboard for the `copy` command |
 
 Testing Code
 -------

--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -144,7 +144,7 @@ func main() {
 	flag.Parse()
 
 	if flag.NArg() == 0 {
-		fmt.Println("Specify a command: version, list, show, copy, pw")
+		fmt.Println("Specify a command: version, list, show, copy, pass")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -203,6 +203,8 @@ func main() {
 		copyEntry(logger, &vault, *cardType, filters)
 	case "pass":
 		entryPassword(logger, &vault, *cardType, filters)
+	default:
+		logger.WithField("command", command).Fatal("unknown command")
 	}
 
 	return

--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -206,7 +206,4 @@ func main() {
 	default:
 		logger.WithField("command", command).Fatal("unknown command")
 	}
-
-	return
-
 }

--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -137,9 +137,9 @@ func main() {
 	keyFilePath := flag.String("keyfile", "", "Path to your Enpass vault keyfile.")
 	logLevelStr := flag.String("log", defaultLogLevel.String(), "The log level from debug (5) to error (1).")
 	nonInteractive := flag.Bool("nonInteractive", false, "Disable prompts and fail instead.")
-	sort := flag.Bool("sort", false, "Sort the output by title and username.")
-	trashed := flag.Bool("trashed", false, "Show trashed items in output.")
-	clipboardPrimary := flag.Bool("clipboardPrimary", false, "Use primary X selection instead of clipboard.")
+	sort := flag.Bool("sort", false, "Sort the output by title and username of the 'list' and 'show' command.")
+	trashed := flag.Bool("trashed", false, "Show trashed items in the 'list' and 'show' command.")
+	clipboardPrimary := flag.Bool("clipboardPrimary", false, "Use primary X selection instead of clipboard for the 'copy' command.")
 
 	flag.Parse()
 

--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -3,15 +3,16 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/atotto/clipboard"
-	"github.com/hazcod/enpass-cli/pkg/enpass"
-	"github.com/miquella/ask"
-	"github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"runtime"
 	s "sort"
 	"strings"
+
+	"github.com/atotto/clipboard"
+	"github.com/hazcod/enpass-cli/pkg/enpass"
+	"github.com/miquella/ask"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -21,7 +22,20 @@ const (
 var (
 	// overwritten by go build
 	version = "dev"
+	// enables prompts
+	interactive = true
 )
+
+func prompt(logger *logrus.Logger, msg string) string {
+	if interactive {
+		if response, err := ask.HiddenAsk("Enter " + msg + ": "); err != nil {
+			logger.WithError(err).Fatal("could not prompt for " + msg)
+		} else {
+			return response
+		}
+	}
+	return ""
+}
 
 func sortEntries(cards []enpass.Card) {
 	// Sort by username preserving original order
@@ -89,20 +103,12 @@ func showEntries(logger *logrus.Logger, vault *enpass.Vault, cardType string, so
 }
 
 func copyEntry(logger *logrus.Logger, vault *enpass.Vault, cardType string, filters []string) {
-	cards, err := vault.GetEntries(cardType, filters)
+	card, err := vault.GetUniqueEntry(cardType, filters)
 	if err != nil {
-		logger.WithError(err).Fatal("could not retrieve cards")
+		logger.WithError(err).Fatal("could not retrieve unique card")
 	}
 
-	if len(cards) == 0 {
-		logger.Fatal("card not found")
-	}
-
-	if len(cards) > 1 {
-		logger.WithField("cards", len(cards)).Fatal("multiple cards match that title")
-	}
-
-	password, err := cards[0].Decrypt()
+	password, err := card.Decrypt()
 	if err != nil {
 		logger.WithError(err).Fatal("could not decrypt card")
 	}
@@ -112,11 +118,25 @@ func copyEntry(logger *logrus.Logger, vault *enpass.Vault, cardType string, filt
 	}
 }
 
+func entryPassword(logger *logrus.Logger, vault *enpass.Vault, cardType string, filters []string) {
+	card, err := vault.GetUniqueEntry(cardType, filters)
+	if err != nil {
+		logger.WithError(err).Fatal("could not retrieve unique card")
+	}
+
+	if password, err := card.Decrypt(); err != nil {
+		logger.WithError(err).Fatal("could not decrypt card")
+	} else {
+		fmt.Println(password)
+	}
+}
+
 func main() {
 	vaultPath := flag.String("vault", "", "Path to your Enpass vault.")
 	cardType := flag.String("type", "password", "The type of your card. (password, ...)")
 	keyFilePath := flag.String("keyfile", "", "Path to your Enpass vault keyfile.")
 	logLevelStr := flag.String("log", defaultLogLevel.String(), "The log level from debug (5) to error (1).")
+	nonInteractive := flag.Bool("nonInteractive", false, "Disable prompts and fail instead.")
 	sort := flag.Bool("sort", false, "Sort the output by title and username.")
 	trashed := flag.Bool("trashed", false, "Show trashed items in output.")
 	clipboardPrimary := flag.Bool("clipboardPrimary", false, "Use primary X selection instead of clipboard.")
@@ -124,7 +144,7 @@ func main() {
 	flag.Parse()
 
 	if flag.NArg() == 0 {
-		fmt.Println("Specify a command: version, list, open, copy")
+		fmt.Println("Specify a command: version, list, show, copy, pw")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -138,6 +158,8 @@ func main() {
 
 	command := strings.ToLower(flag.Arg(0))
 	filters := flag.Args()[1:]
+
+	interactive = !*nonInteractive
 
 	if *clipboardPrimary {
 		clipboard.Primary = true
@@ -154,9 +176,7 @@ func main() {
 
 	masterPassword := os.Getenv("MASTERPW")
 	if masterPassword == "" {
-		if masterPassword, err = ask.HiddenAsk("Enter master password: "); err != nil {
-			logger.WithError(err).Fatal("could not prompt for master password")
-		}
+		masterPassword = prompt(logger, "master password")
 	}
 
 	if masterPassword == "" {
@@ -168,25 +188,23 @@ func main() {
 
 	if err := vault.Initialize(*vaultPath, *keyFilePath, masterPassword); err != nil {
 		logger.WithError(err).Error("could not open vault")
-		os.Exit(2)
+		logger.Exit(2)
 	}
 	defer func() { _ = vault.Close() }()
-	vault.Logger.SetLevel(logLevel)
 
 	logger.Debug("initialized vault")
 
-	switch strings.ToLower(command) {
+	switch command {
 	case "list":
 		listEntries(logger, &vault, *cardType, *sort, *trashed, filters)
-		return
-
 	case "show":
 		showEntries(logger, &vault, *cardType, *sort, *trashed, filters)
-		return
-
 	case "copy":
 		copyEntry(logger, &vault, *cardType, filters)
-		return
+	case "pass":
+		entryPassword(logger, &vault, *cardType, filters)
 	}
+
+	return
 
 }

--- a/pkg/enpass/vault.go
+++ b/pkg/enpass/vault.go
@@ -74,19 +74,19 @@ func (v *Vault) checkPaths() error {
 // Initialize : setup a connection to the Enpass database. Call this before doing anything.
 func (v *Vault) Initialize(databasePath string, keyfilePath string, password string) error {
 	if databasePath == "" {
-		return errors.New("empty v path provided")
+		return errors.New("empty vault path provided")
 	}
 
 	if password == "" {
-		return errors.New("empty v password provided")
+		return errors.New("empty vault password provided")
 	}
 
 	v.databaseFilename = filepath.Join(databasePath, vaultFileName)
 	v.vaultInfoFilename = filepath.Join(databasePath, vaultInfoFileName)
 
-	v.Logger.Debug("checking provided v paths")
+	v.Logger.Debug("checking provided vault paths")
 	if err := v.checkPaths(); err != nil {
-		return errors.Wrap(err, "invalid v path provided")
+		return errors.Wrap(err, "invalid vault path provided")
 	}
 
 	v.Logger.Debug("loading vault info")
@@ -112,7 +112,7 @@ func (v *Vault) Initialize(databasePath string, keyfilePath string, password str
 	v.Logger.Debug("generating master password")
 	masterPassword, err := v.generateMasterPassword([]byte(password), keyfilePath)
 	if err != nil {
-		return errors.Wrap(err, "could not generate v unlock key")
+		return errors.Wrap(err, "could not generate vault unlock key")
 	}
 
 	v.Logger.Debug("extracting salt from database")
@@ -214,4 +214,21 @@ func (v *Vault) GetEntries(cardType string, filters []string) ([]Card, error) {
 	}
 
 	return cards, nil
+}
+
+func (v *Vault) GetUniqueEntry(cardType string, filters []string) (*Card, error) {
+	cards, err := v.GetEntries(cardType, filters)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not retrieve cards")
+	}
+
+	if len(cards) == 0 {
+		return nil, errors.New("card not found")
+	}
+
+	if len(cards) > 1 {
+		return nil, errors.New("multiple cards match that title")
+	}
+
+	return &cards[0], nil
 }

--- a/pkg/enpass/vault.go
+++ b/pkg/enpass/vault.go
@@ -226,9 +226,16 @@ func (v *Vault) GetUniqueEntry(cardType string, filters []string) (*Card, error)
 		return nil, errors.New("card not found")
 	}
 
-	if len(cards) > 1 {
-		return nil, errors.New("multiple cards match that title")
+	var uniqueCard *Card
+	for _, card := range cards {
+		if card.IsTrashed() || card.IsDeleted() {
+			continue
+		} else if uniqueCard == nil {
+			uniqueCard = &card
+		} else {
+			return nil, errors.New("multiple cards match that title")
+		}
 	}
 
-	return &cards[0], nil
+	return uniqueCard, nil
 }


### PR DESCRIPTION
- solves #102 by introducing the new command `pass`. works identical to `copy` but writes to stdout instead of clipboard
- add non-interactive mode by introducing the flag `-nonInteractive`, useful for scripting
- improve README with command/flag tables