### PR TITLE
check value length and card type before decrypt

### DIFF
--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -122,7 +122,7 @@ func listEntries(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
 		logger.Printf(
 			"> title: %s"+
 				"  login: %s"+
-				"  cat. : %s",
+				"  cat.: %s",
 			card.Title,
 			card.Subtitle,
 			card.Category,
@@ -151,11 +151,12 @@ func showEntries(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
 		logger.Printf(
 			"> title: %s"+
 				"  login: %s"+
-				"  cat. : %s"+
-				"  pass : %s",
+				"  cat.: %s"+
+				"  %s: %s",
 			card.Title,
 			card.Subtitle,
 			card.Category,
+			card.Type,
 			decrypted,
 		)
 	}

--- a/pkg/enpass/card.go
+++ b/pkg/enpass/card.go
@@ -90,6 +90,16 @@ func (c *Card) IsDeleted() bool {
 }
 
 func (c *Card) Decrypt() (string, error) {
+	// Intercept item fields without value
+	if len(c.value) == 0 {
+		return "", nil
+	}
+
+	// Intercept non-password item fields, their value isn't encrypted
+	if c.Type != "password" {
+		return c.value, nil
+	}
+
 	// The key object is saved in binary from and actually consists of the
 	// AES key (32 bytes) and a nonce (12 bytes) for GCM
 	key := c.itemKey[:32]


### PR DESCRIPTION
- fixes #114 
- fixes reading field types other than the default `password`, e.g. `-type=ccPin` for credit cards