### PR TITLE
add label to output

### DIFF
--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -130,10 +130,12 @@ func listEntries(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
 		logger.Printf(
 			"> title: %s"+
 				"  login: %s"+
-				"  cat.: %s",
+				"  cat.: %s"+
+				"  label: %s",
 			card.Title,
 			card.Subtitle,
 			card.Category,
+			card.Label,
 		)
 	}
 }
@@ -160,10 +162,12 @@ func showEntries(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
 			"> title: %s"+
 				"  login: %s"+
 				"  cat.: %s"+
+				"  label: %s"+
 				"  %s: %s",
 			card.Title,
 			card.Subtitle,
 			card.Category,
+			card.Label,
 			card.Type,
 			decrypted,
 		)


### PR DESCRIPTION
Currently if I store my card like this:

<img width="723" alt="card" src="https://github.com/user-attachments/assets/ed83f416-ecae-4c40-bf2e-d720dea5b712">

And I want to show passwords with `enp show FooBar`, it will output the following:

```bash
INFO[0002] > title: FooBar  login:   cat.: computer  password: my-secret-password-1
INFO[0002] > title: FooBar  login:   cat.: computer  password: my-secret-password-2
```

Which makes it impossible to use, because I don't know which password is which.

The PR adds a label to the output:

```bash
INFO[0003] > title: FooBar  login:   cat.: computer  label: DB_PASSWORD  password: my-secret-password-1
INFO[0003] > title: FooBar  login:   cat.: computer  label: OTHER_SECRET  password: my-secret-password-2
```

Which makes it very clear.