### PR TITLE
Add JSON Output Option and Refactor Data Preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ enp show enpass.com
 $ # copy password of 'reddit.com' entry to clipboard
 $ enp copy reddit.com
 
-$ # print password of 'github.com' to stdout, useful for scripting 
+$ # print password of 'github.com' to stdout, useful for scripting
 $ password=$(enp pass github.com)
 ```
 
@@ -47,6 +47,7 @@ Flags
 | `-type=TYPE` | The type of your card (password, ...) |
 | `-log=LEVEL` | The log level from debug (5) to error (1) |
 | `-nonInteractive` | Disable prompts and fail instead |
+| `-json` | Output as JSON to stdout |
 | `-pin` | Enable Quick Unlock using a PIN |
 | `-and` | Combines filters with AND instead of default OR |
 | `-sort` | Sort the output by title and username of the `list` and `show` command |


### PR DESCRIPTION
This pull request introduces a new `-json` flag, allowing output in JSON format for more flexible data handling and integration with other scripts. At the moment I'm trying to make `enpass-cli` work with Kamal https://github.com/basecamp/kamal/pull/1189#discussion_r1827780661

The change refactors the code by encapsulating card data preparation and output functionalities into reusable functions: `prepareCardData` and `outputDataOrLog`. The key points of this PR are:

## Simple usage

```
> go run ./cmd/... -json -vault=path/to/vault list FooBar

Enter vault password:
[{"category":"computer","label":"DB_PASSWORD","login":"","title":"FooBar","type":"password"},{"category":"computer","label":"OTHER_SECRET","login":"","title":"FooBar","type":"password"},{"category":"computer","label":"","login":"","title":"FooBar","type":"password"},{"category":"computer","label":"","login":"","title":"FooBar","type":"password"}]
```

## In combination with other scripts

```
> go run ./cmd/... -json -vault=path/to/vault list FooBar | jq

Enter vault password:
[
  {
    "category": "computer",
    "label": "DB_PASSWORD",
    "login": "",
    "title": "FooBar",
    "type": "password"
  },
  {
    "category": "computer",
    "label": "OTHER_SECRET",
    "login": "",
    "title": "FooBar",
    "type": "password"
  },
  {
    "category": "computer",
    "label": "",
    "login": "",
    "title": "FooBar",
    "type": "password"
  },
  {
    "category": "computer",
    "label": "",
    "login": "",
    "title": "FooBar",
    "type": "password"
  }
]
```

The same also works with `show` function.