### PR TITLE
chore: update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/hazcod/enpass-cli
 
-go 1.22.0
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
update go.mod to fix build issue seen in https://github.com/hazcod/enpass-cli/actions/runs/15673763396/job/44149452486#step:10:34 and https://github.com/Homebrew/homebrew-core/pull/227000