### PR TITLE
feat: add env command for shell-consumable vault export

### DIFF
--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -37,6 +37,7 @@ const (
 	cmdTrash   = "trash"
 	cmdRestore = "restore"
 	cmdDelete  = "delete"
+	cmdEnv     = "env"
 
 	// defaults
 	defaultLogLevel        = logrus.InfoLevel
@@ -51,7 +52,7 @@ var (
 	commands = map[string]struct{}{
 		cmdVersion: {}, cmdHelp: {}, cmdDryRun: {}, cmdList: {},
 		cmdShow: {}, cmdCopy: {}, cmdPass: {}, cmdUi: {},
-		cmdCreate: {}, cmdEdit: {}, cmdTrash: {}, cmdRestore: {}, cmdDelete: {},
+		cmdCreate: {}, cmdEdit: {}, cmdTrash: {}, cmdRestore: {}, cmdDelete: {}, cmdEnv: {},
 	}
 )
 
@@ -72,6 +73,7 @@ type Args struct {
 	detailed         *bool
 	and              *bool
 	clipboardPrimary *bool
+	field            *string
 	// write command flags
 	title    *string
 	login    *string
@@ -95,6 +97,7 @@ func (args *Args) parse() {
 	args.trashed = flag.Bool("trashed", false, "Show trashed items in the 'list' and 'show' command.")
 	args.detailed = flag.Bool("detailed", false, "Show every field of each entry in 'list' and 'show'. Without this flag, only the original summary fields (title, login, category, label, type) are displayed.")
 	args.clipboardPrimary = flag.Bool("clipboardPrimary", false, "Use primary X selection instead of clipboard for the 'copy' command.")
+	args.field = flag.String("field", "", "Field label to extract (default: password). Used with 'env' command.")
 	// write command flags
 	args.title = flag.String("title", "", "Entry title (for create/edit).")
 	args.login = flag.String("login", "", "Username or email (for create/edit).")
@@ -131,6 +134,7 @@ func printHelp() {
 	fmt.Println("  show [filter]     Show entries (with passwords; computes RFC 6238 TOTP code)")
 	fmt.Println("  copy <filter>     Copy password to clipboard")
 	fmt.Println("  pass <filter>     Print password to stdout")
+	fmt.Println("  env [filter]      Output entry field as KEY=VALUE for shell eval")
 	fmt.Println("  ui                Interactive terminal UI")
 	fmt.Println("  create            Create a new entry")
 	fmt.Println("  edit <filter>     Edit an existing entry")
@@ -145,6 +149,11 @@ func printHelp() {
 	fmt.Println("only the summary fields (title, login, category, label, type). TOTP fields")
 	fmt.Println("are treated as sensitive: their secret is hidden in list, and show prints")
 	fmt.Println("the current RFC 6238 code alongside the secret.")
+	fmt.Println()
+	fmt.Println("The env command outputs vault values as shell-safe KEY='value' lines.")
+	fmt.Println("Use -field to select a specific field label (default: password).")
+	fmt.Println("  eval $(enpass-cli -vault /path env MY_SECRET=\"entry title\")")
+	fmt.Println("  eval $(enpass-cli -vault /path env -field \"Access Key\" AWS_KEY=\"AWS\")")
 	fmt.Println()
 	fmt.Println("Flags:")
 	flag.Usage()
@@ -480,6 +489,116 @@ func entryPassword(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
 	} else {
 		fmt.Println(decrypted)
 	}
+}
+
+func envEntries(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
+	if len(args.filters) == 0 {
+		logger.Fatal("env command requires at least one VARNAME=filter argument")
+	}
+
+	type envPair struct {
+		Name  string
+		Value string
+	}
+
+	var pairs []envPair
+
+	for _, arg := range args.filters {
+		eqIdx := strings.Index(arg, "=")
+		if eqIdx < 1 {
+			logger.Fatalf("invalid argument %q: expected VARNAME=filter", arg)
+		}
+
+		varName := arg[:eqIdx]
+		filter := arg[eqIdx+1:]
+
+		var value string
+
+		if *args.field == "" {
+			card, err := vault.GetEntry(*args.cardType, []string{filter}, true)
+			if err != nil {
+				logger.WithError(err).Fatalf("could not retrieve entry for %s", varName)
+			}
+
+			decrypted, err := card.Decrypt()
+			if err != nil {
+				logger.WithError(err).Fatalf("could not decrypt entry for %s", varName)
+			}
+
+			value = decrypted
+		} else {
+			cards, err := vault.GetAllFields(*args.cardType, []string{filter})
+			if err != nil {
+				logger.WithError(err).Fatalf("could not retrieve fields for %s", varName)
+			}
+
+			// Group by entry UUID and enforce uniqueness.
+			entries := make(map[string][]enpass.Card)
+			var order []string
+			for _, c := range cards {
+				if c.IsDeleted() || c.IsTrashed() {
+					continue
+				}
+				if _, seen := entries[c.UUID]; !seen {
+					order = append(order, c.UUID)
+				}
+				entries[c.UUID] = append(entries[c.UUID], c)
+			}
+
+			if len(entries) == 0 {
+				logger.Fatalf("no entry found matching filter for %s", varName)
+			}
+			if len(entries) > 1 {
+				logger.Fatalf("multiple entries match filter for %s, refine your filter", varName)
+			}
+
+			// Find the field matching -field label.
+			fields := entries[order[0]]
+			var match *enpass.Card
+			for i, c := range fields {
+				if strings.EqualFold(c.Label, *args.field) {
+					match = &fields[i]
+					break
+				}
+			}
+
+			if match == nil {
+				logger.Fatalf("no field %q found in entry for %s", *args.field, varName)
+			}
+
+			decrypted, err := match.Decrypt()
+			if err != nil {
+				logger.WithError(err).Fatalf("could not decrypt field %q for %s", *args.field, varName)
+			}
+
+			value = decrypted
+		}
+
+		pairs = append(pairs, envPair{Name: varName, Value: value})
+	}
+
+	if *args.jsonOutput {
+		result := make(map[string]string, len(pairs))
+		for _, p := range pairs {
+			result[p.Name] = p.Value
+		}
+
+		jsonData, err := json.Marshal(result)
+		if err != nil {
+			logger.WithError(err).Fatal("could not marshal JSON output")
+		}
+
+		fmt.Println(string(jsonData))
+		return
+	}
+
+	for _, p := range pairs {
+		fmt.Printf("%s='%s'\n", p.Name, shellQuote(p.Value))
+	}
+}
+
+func shellQuote(s string) string {
+	return strings.ReplaceAll(s, "'", "'\\''")
 }
 
 func ui(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
@@ -893,6 +1012,8 @@ func main() {
 		trashEntry(logger, vault, args)
 	case cmdRestore:
 		restoreEntry(logger, vault, args)
+	case cmdEnv:
+		envEntries(logger, vault, args)
 	case cmdDelete:
 		deleteEntry(logger, vault, args)
 	default:

--- a/cmd/enpasscli/main.go
+++ b/cmd/enpasscli/main.go
@@ -134,7 +134,7 @@ func printHelp() {
 	fmt.Println("  show [filter]     Show entries (with passwords; computes RFC 6238 TOTP code)")
 	fmt.Println("  copy <filter>     Copy password to clipboard")
 	fmt.Println("  pass <filter>     Print password to stdout")
-	fmt.Println("  env [filter]      Output entry field as KEY=VALUE for shell eval")
+	fmt.Println("  env VARNAME=filter  Output entry field as KEY=VALUE for shell eval")
 	fmt.Println("  ui                Interactive terminal UI")
 	fmt.Println("  create            Create a new entry")
 	fmt.Println("  edit <filter>     Edit an existing entry")
@@ -496,12 +496,10 @@ func envEntries(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
 		logger.Fatal("env command requires at least one VARNAME=filter argument")
 	}
 
-	type envPair struct {
-		Name  string
-		Value string
+	var jsonResult map[string]string
+	if *args.jsonOutput {
+		jsonResult = make(map[string]string, len(args.filters))
 	}
-
-	var pairs []envPair
 
 	for _, arg := range args.filters {
 		eqIdx := strings.Index(arg, "=")
@@ -511,6 +509,15 @@ func envEntries(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
 
 		varName := arg[:eqIdx]
 		filter := arg[eqIdx+1:]
+
+		for _, r := range varName {
+			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_') {
+				logger.Fatalf("invalid variable name %q: must contain only letters, digits, and underscores", varName)
+			}
+		}
+		if varName[0] >= '0' && varName[0] <= '9' {
+			logger.Fatalf("invalid variable name %q: must not start with a digit", varName)
+		}
 
 		var value string
 
@@ -527,7 +534,12 @@ func envEntries(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
 
 			value = decrypted
 		} else {
-			cards, err := vault.GetAllFields(*args.cardType, []string{filter})
+			typeFilter := *args.cardType
+			if typeFilter == "password" {
+				typeFilter = ""
+			}
+
+			cards, err := vault.GetAllFields(typeFilter, []string{filter})
 			if err != nil {
 				logger.WithError(err).Fatalf("could not retrieve fields for %s", varName)
 			}
@@ -574,26 +586,19 @@ func envEntries(logger *logrus.Logger, vault *enpass.Vault, args *Args) {
 			value = decrypted
 		}
 
-		pairs = append(pairs, envPair{Name: varName, Value: value})
+		if jsonResult != nil {
+			jsonResult[varName] = value
+		} else {
+			fmt.Printf("%s='%s'\n", varName, shellQuote(value))
+		}
 	}
 
-	if *args.jsonOutput {
-		result := make(map[string]string, len(pairs))
-		for _, p := range pairs {
-			result[p.Name] = p.Value
-		}
-
-		jsonData, err := json.Marshal(result)
+	if jsonResult != nil {
+		jsonData, err := json.Marshal(jsonResult)
 		if err != nil {
 			logger.WithError(err).Fatal("could not marshal JSON output")
 		}
-
 		fmt.Println(string(jsonData))
-		return
-	}
-
-	for _, p := range pairs {
-		fmt.Printf("%s='%s'\n", p.Name, shellQuote(p.Value))
 	}
 }
 


### PR DESCRIPTION
Adds an `env` subcommand that outputs vault field values as shell-safe `KEY='value'` lines, designed for `eval $(enpass-cli env ...)` workflows.

## Usage

```bash
# Default: extract the password field
enpass-cli -vault /path env GITHUB_TOKEN="GitHub Personal"
# Output: GITHUB_TOKEN='ghp_abc123...'

# Specific field via -field flag
enpass-cli -vault /path env -field "Access Key" AWS_KEY="AWS"
# Output: AWS_KEY='AKIA...'

# JSON output
enpass-cli -vault /path -json env MY_SECRET="entry title"
# Output: {"MY_SECRET":"..."}

# Shell integration
eval $(enpass-cli -vault /path env DB_PASS="Production DB")
```

## Summary

- Each positional arg is a `VARNAME=filter` pair — the filter uses the same substring matching as existing commands
- `VARNAME` is validated as a POSIX shell identifier (`[a-zA-Z_][a-zA-Z0-9_]*`) to prevent injection when output is `eval`'d
- Optional `-field` flag selects which field label to extract (default: password field)
- When `-field` is set, the default `cardType` filter is cleared so non-password field types (username, email, custom fields) are reachable
- Values are single-quoted with `'` escaped as `'\''` for safe shell eval
- Supports `-json` for programmatic consumption
- Two resolution paths: without `-field` uses `GetEntry()` (same as `pass`), with `-field` uses `GetAllFields()` + case-insensitive label matching
- Text mode outputs each pair immediately; JSON mode accumulates into a flat `{"KEY":"value"}` object

https://claude.ai/code/session_01Lr7gquKQVPezfc8NvN39q8